### PR TITLE
Potential fix for code scanning alert no. 2: Server-side request forgery

### DIFF
--- a/Server1/crawler.js
+++ b/Server1/crawler.js
@@ -1,6 +1,26 @@
 const axios = require("axios");
 const cheerio = require("cheerio");
 const { savePage } = require("./db");
+const { URL } = require("url");
+
+// Allow-list of domains to crawl
+const ALLOWED_DOMAINS = [
+  "example.com",
+  // Add more allowed domains as needed
+];
+
+function isAllowedUrl(urlString) {
+  try {
+    const parsed = new URL(urlString);
+    // Check if the hostname ends with one of the allowed domains
+    return ALLOWED_DOMAINS.some(domain =>
+      parsed.hostname === domain ||
+      parsed.hostname.endsWith("." + domain)
+    );
+  } catch (e) {
+    return false;
+  }
+}
 
 const visited = new Set();
 
@@ -8,6 +28,10 @@ async function crawl(url, depth = 1) {
   if (visited.has(url) || depth === 0) return;
   visited.add(url);
 
+    if (!isAllowedUrl(url)) {
+      console.warn(`Skipping disallowed URL: ${url}`);
+      return;
+    }
   try {
     const { data } = await axios.get(url, { timeout: 5000 });
     const $ = cheerio.load(data);


### PR DESCRIPTION
Potential fix for [https://github.com/Glowing-Jellyfishings/glowing-jellyfishings/security/code-scanning/2](https://github.com/Glowing-Jellyfishings/glowing-jellyfishings/security/code-scanning/2)

To fix the SSRF vulnerability, we should restrict the URLs that can be crawled. The best approach is to validate each URL before making a request, ensuring it matches a set of allowed hostnames or domains. This can be done by maintaining an allow-list of domains (e.g., only crawl URLs from `example.com` and its subdomains), and checking each URL against this list before proceeding. The validation should be performed in the `crawl` function, before calling `axios.get`. If a URL does not match the allow-list, it should be skipped and not crawled.

**Required changes:**
- Add an allow-list of domains at the top of the file.
- Add a helper function to validate URLs against the allow-list.
- In the `crawl` function, check the URL before making the request; if invalid, skip crawling.
- Add the required import for Node's `url` module to parse hostnames.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
